### PR TITLE
Update README.md for Mavlink headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Some plugins on this packages require some specific dependencies:
 * Protobuf is required to generate custom protobuf messages to be published and subscribed between topics of different plugins;
 * Jinja 2 is used to generate some SDF models from templates;
 * Gstreamer is required for a plugin that streams video from a simulated camera.
-
+* Mavlink v2.0 header files.
 
 ### Ubuntu 
 
@@ -79,6 +79,19 @@ sudo pacman -S --noconfirm --needed eigen3 hdf5 opencv protobuf vtk yay python2-
 sudo pacman -S --needed gstreamer gst-plugins-bad gst-plugins-base gst-plugins-base-libs gst-plugins-good gst-plugins-ugly
 ```
 
+### Mavlink header files
+
+There is a dependency on the Mavlink v2.0 header files and these files can be installed either using a build 
+of `PX4/Firmware` or installing the ROS package `ros-<distro>-mavlink`.  If build fails with missing header
+files or function parameter mis-match problems, then you can clone and install the files as follows (for Ubuntu):
+
+```bash
+mkdir -p ~/src/mavlink
+cd src/mavlink
+git clone --depth 1 https://github.com/mavlink/c_library_v2.git
+sudo mkdir -p /usr/local/include/mavlink/v2.0
+sudo cp -rf ~/src/mavlink/c_library_v2/* /usr/local/include/mavlink/v2.0
+```
 
 ## Build *sitl_gazebo*
 


### PR DESCRIPTION
I found the same problem as reported in <https://github.com/PX4/sitl_gazebo/pull/509> when building the master branch of this repo using:

* ROS Eloquent
* Gazebo 9
* Mavlink v.2.0 installed from `sudo apt install ros-eloquent-mavlink`.

My "fix" is to update the README.md file to include instructions on how to clone and install the Mavlink v2.0 header files if there is a header file mismatch in your build.
